### PR TITLE
script to inject enrich-classpath for deps.edn projects

### DIFF
--- a/scripts/clojure-deps
+++ b/scripts/clojure-deps
@@ -43,11 +43,11 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
 (defn source-paths?
   "This function identify a :source-path resource e.g. src, test folders in class path.
 
-  A valid classpath string is something like this:
+  A valid classpath string is something like these:
 
   /Users/wferreir/.m2/repository/org/clojure/clojure/1.10.3/clojure-1.10.3.jar
-
-  This functions receives a vector after string/split #/ on the string above.
+  src/my-project
+  test/my-project
   "
   [classpath]
   (or (string/starts-with? classpath "src")

--- a/scripts/clojure-deps
+++ b/scripts/clojure-deps
@@ -1,0 +1,103 @@
+#!/bin/sh
+#_(
+   #_DEPS is same format as deps.edn. Multiline is okay.
+   DEPS='
+   {:deps {mx.cider/enrich-classpath {:mvn/version "1.4.1"}
+           clj-commons/pomegranate {:mvn/version "1.2.0"}
+           leiningen-core/leiningen-core {:mvn/version "2.9.6"}
+           babashka/process {:mvn/version "0.0.2"}}}
+   '
+exec clojure -Sdeps "$DEPS" "$0" "$@"
+   )
+
+;; bash hack from here https://gist.github.com/ericnormand/6bb4562c4bc578ef223182e3bb1e72c5
+;;
+;; Allow injecting Enrich Classpath code before starting Clojure
+
+
+(require '[babashka.process :as process]
+         '[clojure.string :as string]
+         '[cider.enrich-classpath :as enrich]
+         '[leiningen.core.classpath :as classpath]
+         '[clojure.pprint :as pprint])
+
+(def repositories
+  [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
+   ["clojars" {:url "https://repo.clojars.org/"}]])
+
+(defn get-aliases
+  [args]
+  (when args
+    (->> (string/split args #":")
+         (drop 1)
+         (string/join ":")
+         (str "-X:"))))
+
+(defn get-initial-classpath
+  [args]
+  (let [cmd ["clojure" "-Spath" (get-aliases args)]]
+    (-> (process/process cmd)
+        :out
+        slurp)))
+
+(defn source-paths?
+  "This function identify a :source-path resource e.g. src, test folders in class path.
+
+  A valid classpath string is something like this:
+
+  /Users/wferreir/.m2/repository/org/clojure/clojure/1.10.3/clojure-1.10.3.jar
+
+  This functions receives a vector after string/split #/ on the string above.
+  "
+  [classpath]
+  (or (string/starts-with? classpath "src")
+      (string/starts-with? classpath "test")))
+
+(defn gitlibs?
+  "In deps.edn projects we can get dependencies from Github using SHA value.
+
+  They are saved in $HOME/.gitlibs folder.
+
+  These libraries are current not supported in the project."
+  [classpath]
+  (string/starts-with? classpath (str (System/getProperty "user.home") "/.gitlibs")))
+
+(defn leiningen-deps-structure
+  [classpath]
+  (->> (string/split classpath #":")
+       (filter #(and (not (source-paths? %))
+                     (not (gitlibs? %))))
+       (map #(let[coords (->> (string/split % #"\/")
+                              (drop 4)
+                              (drop-last))
+                  deps-version (first (take-last 1 coords))
+                  deps-name (first (take-last 1 (drop-last coords)))
+                  deps-group (string/join "." (drop 1 (drop-last (drop-last coords))))]
+               (when (and deps-group deps-name)
+                 [(symbol (str deps-group "/" deps-name))
+                  deps-version])))
+       (filter some?)))
+
+(defn ->lein-project-map
+  [dependencies]
+  {:dependencies dependencies
+   :repositories repositories})
+
+;; bug with babashka.process and pprint https://github.com/babashka/process#clojurepprint
+(prefer-method pprint/simple-dispatch clojure.lang.IPersistentMap clojure.lang.IDeref)
+
+(let [aliases-args (first *command-line-args*)
+      initial-classpath (get-initial-classpath aliases-args)
+      project (-> initial-classpath
+                  leiningen-deps-structure
+                  ->lein-project-map
+                  enrich/middleware)
+      enriched-classpath (string/join ":" (classpath/get-classpath project))
+      final-classpath (str initial-classpath ":" enriched-classpath)
+      command (concat ["clojure" "-Scp" final-classpath] *command-line-args*)]
+
+  (-> (process/process command {:out :inherit})
+      (process/check))
+
+  ;; force termination
+  (shutdown-agents))

--- a/scripts/clojure-deps
+++ b/scripts/clojure-deps
@@ -17,6 +17,7 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
 
 (require '[babashka.process :as process]
          '[clojure.string :as string]
+         '[clojure.edn :as edn]
          '[cider.enrich-classpath :as enrich]
          '[leiningen.core.classpath :as classpath]
          '[clojure.pprint :as pprint])
@@ -83,13 +84,40 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
   {:dependencies dependencies
    :repositories repositories})
 
+(defn get-sdeps
+  [args]
+  (let [maybe-deps (reduce
+                    (fn [has-extra-deps? arg]
+                      (if has-extra-deps?
+                        (reduced arg)
+                        (if (= "-Sdeps" arg)
+                          true
+                          false)))
+                    false
+                    args)]
+    (when (string? maybe-deps)
+      (edn/read-string maybe-deps))))
+
+(defn sdep-version
+  [deps dep-name]
+  (:mvn/version (get deps dep-name)))
+
+(defn sdeps->leiningen-deps-structure
+  [deps-edn]
+  (let [deps (:deps deps-edn)
+        dep-names (keys deps)]
+    (for [dep-name dep-names]
+      [dep-name (sdep-version deps dep-name)])))
+
+
 ;; bug with babashka.process and pprint https://github.com/babashka/process#clojurepprint
 (prefer-method pprint/simple-dispatch clojure.lang.IPersistentMap clojure.lang.IDeref)
 
 (let [aliases-args (first *command-line-args*)
       initial-classpath (get-initial-classpath aliases-args)
-      project (-> initial-classpath
-                  leiningen-deps-structure
+      dependencies (concat (leiningen-deps-structure initial-classpath)
+                           (sdeps->leiningen-deps-structure (get-sdeps *command-line-args*)))
+      project (-> dependencies
                   ->lein-project-map
                   enrich/middleware)
       enriched-classpath (string/join ":" (classpath/get-classpath project))

--- a/scripts/clojure-deps
+++ b/scripts/clojure-deps
@@ -13,14 +13,10 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
 ;; bash hack from here https://gist.github.com/ericnormand/6bb4562c4bc578ef223182e3bb1e72c5
 ;;
 ;; Allow injecting Enrich Classpath code before starting Clojure
-
-
 (require '[babashka.process :as process]
          '[clojure.string :as string]
-         '[clojure.edn :as edn]
          '[cider.enrich-classpath :as enrich]
-         '[leiningen.core.classpath :as classpath]
-         '[clojure.pprint :as pprint])
+         '[leiningen.core.classpath :as classpath])
 
 (def repositories
   [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
@@ -28,28 +24,42 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
 
 (defn get-aliases
   [args]
-  (when args
-    (->> (string/split args #":")
-         (drop 1)
-         (string/join ":")
-         (str "-X:"))))
+  (reduce
+   (fn [aliases arg]
+     (let [exec-opt (subs arg 0 2)
+           aliasable? (contains? #{"-A" "-T" "-X" "-M"} exec-opt)]
+       (when aliasable?
+         (reduced (string/join ":" (drop 1 (string/split arg #":")))))))
+   nil
+   args))
+
+(defn get-sdeps
+  [args]
+  (reduce
+   (fn [has-extra-deps? arg]
+     (if has-extra-deps?
+       (reduced arg)
+       (when (= "-Sdeps" arg)
+         true)))
+   nil
+   args))
 
 (defn get-initial-classpath
   [args]
-  (let [cmd ["clojure" "-Spath" (get-aliases args)]]
-    (-> (process/process cmd)
+  (let [alias (get-aliases args)
+        sdeps (get-sdeps args)
+        cmd-with-alias (when alias [(str "-X:" alias)])
+        cmd-with-sdeps (when sdeps ["-Sdeps" sdeps])]
+    (-> ["clojure"]
+        (concat cmd-with-sdeps
+                ["-Spath"]
+                cmd-with-alias)
+        process/process
         :out
         slurp)))
 
 (defn source-paths?
-  "This function identify a :source-path resource e.g. src, test folders in class path.
-
-  A valid classpath string is something like these:
-
-  /Users/wferreir/.m2/repository/org/clojure/clojure/1.10.3/clojure-1.10.3.jar
-  src/my-project
-  test/my-project
-  "
+  "This function identify a :source-path resource e.g. src, test folders in class path."
   [classpath]
   (or (string/starts-with? classpath "src")
       (string/starts-with? classpath "test")))
@@ -84,40 +94,13 @@ exec clojure -Sdeps "$DEPS" "$0" "$@"
   {:dependencies dependencies
    :repositories repositories})
 
-(defn get-sdeps
-  [args]
-  (let [maybe-deps (reduce
-                    (fn [has-extra-deps? arg]
-                      (if has-extra-deps?
-                        (reduced arg)
-                        (if (= "-Sdeps" arg)
-                          true
-                          false)))
-                    false
-                    args)]
-    (when (string? maybe-deps)
-      (edn/read-string maybe-deps))))
-
-(defn sdep-version
-  [deps dep-name]
-  (:mvn/version (get deps dep-name)))
-
-(defn sdeps->leiningen-deps-structure
-  [deps-edn]
-  (let [deps (:deps deps-edn)
-        dep-names (keys deps)]
-    (for [dep-name dep-names]
-      [dep-name (sdep-version deps dep-name)])))
-
-
 ;; bug with babashka.process and pprint https://github.com/babashka/process#clojurepprint
+(require '[clojure.pprint :as pprint])
 (prefer-method pprint/simple-dispatch clojure.lang.IPersistentMap clojure.lang.IDeref)
 
-(let [aliases-args (first *command-line-args*)
-      initial-classpath (get-initial-classpath aliases-args)
-      dependencies (concat (leiningen-deps-structure initial-classpath)
-                           (sdeps->leiningen-deps-structure (get-sdeps *command-line-args*)))
-      project (-> dependencies
+(let [initial-classpath (get-initial-classpath *command-line-args*)
+      project (-> initial-classpath
+                  leiningen-deps-structure
                   ->lein-project-map
                   enrich/middleware)
       enriched-classpath (string/join ":" (classpath/get-classpath project))


### PR DESCRIPTION
Proposal to fix #2 .

A problem: `cider-jack-in` adds middleware on-the-fly using `-Sdeps EDN     Deps data to use as the last deps file to be merged` however -Scp does not work together with -Sdeps.

I need to extend this code to understand the -Sdeps option and include it in the classpath too, I am pushing this code for review anyway.