### PR TITLE
Only add jdk-sources to resource-paths if there are any

### DIFF
--- a/src/cider/enrich_classpath/jdk_sources.clj
+++ b/src/cider/enrich_classpath/jdk_sources.clj
@@ -23,7 +23,8 @@
                (io/file home "lib" f)
                (io/file parent f)
                (io/file parent "lib" f)]]
-    (->> paths (filter #(.canRead ^File %)) first str)))
+    (when-let [path (->> paths (filter #(.canRead ^File %)) first)]
+      (str path))))
 
 (defn java-path->zip-path [path]
   (some-> (io/resource path)
@@ -90,4 +91,4 @@
 (defn resources-to-add []
   (cond-> []
     jdk8? (conj (unzipped-jdk-source))
-    true  (conj jdk-sources)))
+    jdk-sources  (conj jdk-sources)))

--- a/test/unit/cider/enrich_classpath.clj
+++ b/test/unit/cider/enrich_classpath.clj
@@ -1,6 +1,7 @@
 (ns unit.cider.enrich-classpath
   (:require
    [cider.enrich-classpath :as sut]
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]))
 
 (deftest matches-version?
@@ -66,3 +67,8 @@
 (deftest tools-jar-path
   (is (= (some? (re-find #"^1\.8\." (System/getProperty "java.version")))
          (some? (sut/tools-jar-path)))))
+
+(deftest add-project
+  (testing ":resource-paths does not contain any empty entries"
+    (let [{:keys [resource-paths]} (sut/add {:resource-paths []})]
+      (is  (empty? (filter str/blank? resource-paths))))))


### PR DESCRIPTION
Hi,

could you please consider a hack to ensure there are no empty paths introduced to `:resource-paths`.

fixes #12.

This causes an issue with lein. The latter tries to go through the directories in the project's `:resource-path` ([source](https://github.com/technomancy/leiningen/blob/5be95496d624220cb334a46c0c8429deee3c3945/leiningen-core/src/leiningen/core/eval.clj#L81) that will cause it to attempt to create an empty dir, as introduced by `enrich`.

When `enrich` fails to find `src.zip`, it returns an empty string (courtesy of `str`'ing a `nil`), which makes it through to the resource-paths.

```clojure
(defn jdk-find [f]
  (let [home (io/file (System/getProperty "java.home"))
        parent (.getParentFile home)
        paths [(io/file home f)
               (io/file home "lib" f)
               (io/file parent f)
               (io/file parent "lib" f)]]
    (->> paths (filter #(.canRead ^File %)) first str)))


(def jdk-sources
  (or (java-path->zip-path "java.base/java/lang/Object.java") ;; JDK9+
      (java-path->zip-path "java/lang/Object.java")           ;; JDK8-
      (jdk-find "src.zip")))
```

As you can see this only happens when the first two entries in the or doe not match (thus jdk version specific).

I've added a unit test to demonstrate an empty path comes back in resources.

This is a quick hack, I am not familiar with the codebase, feel free to update as you please.

Thanks.
