### PR TITLE
Implement `:shorten` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ The `~/.enrich-classpath-cache` file has a stable format. You can version-contro
 
 This program observes a number of Lein configuration options under the `:enrich-classpath` key:
 
+#### `:shorten`
+
+Default: `false`.
+
+If `true`, most classpath entries will be added as a single, very thin .jar file,
+which contents will consist of a single `MANIFEST.MF` file which will point of all those classpath entries.
+
+This results in a shorter `java` process name, which avoids incurring into the length limitations that Linux programs can be subject to.
+
+There isn't a visible difference in behavior around using this option: with or without it, entries will be added to the classpath effectively
+in the same way, and e.g. `clojure.java.io/resource` will keep pointing to the right jar (i.e. the final one, not the thin one that points to it).
+
 #### `:classifiers`
 
 By default, both sources and javadocs will be fetched. By specifying only `sources` to be fetched, one gets a 2x performance improvement (because 0.5x as many items will be attempted to be resolved):

--- a/integration-testing/integration_test.clj
+++ b/integration-testing/integration_test.clj
@@ -97,32 +97,32 @@
     ;; uses lein-tools-deps:
     "overtone"      vanilla-lein-deps
     ;; uses lein-sub, lein-modules:
-    "incanter"      (reduce into [(prelude lein)
-                                  ["sub" "do"]
-                                  (prelude "install,")
-                                  ["deps"]])
+    "incanter"      (reduce into [] [(prelude lein)
+                                     ["sub" "do"]
+                                     (prelude "install,")
+                                     ["deps"]])
     ;; uses lein-sub:
-    "icepick"       (with-meta (reduce into [(prelude lein)
-                                             (prelude "sub")
-                                             ["deps"]])
+    "icepick"       (with-meta (reduce into [] [(prelude lein)
+                                                (prelude "sub")
+                                                ["deps"]])
                       ;; Icepick seemingly relies on tools.jar, unavailable in JDK9+
                       {::skip-in-newer-jdks true})
     ;; uses lein-sub:
-    "crux"          (reduce into [(prelude lein)
-                                  (prelude "sub")
-                                  ["deps"]])
+    "crux"          (reduce into [] [(prelude lein)
+                                     (prelude "sub")
+                                     ["deps"]])
     ;; uses lein-sub:
-    "pedestal"      (reduce into [(prelude lein)
-                                  (prelude "sub")
-                                  ["deps"]])
+    "pedestal"      (reduce into [] [(prelude lein)
+                                     (prelude "sub")
+                                     ["deps"]])
     ;; uses lein-monolith:
-    "sparkplug"     (with-meta (reduce into [(prelude lein)
-                                             ["monolith"]
-                                             (prelude "each")
-                                             ["do"
-                                              "clean,"
-                                              "install,"
-                                              "deps"]])
+    "sparkplug"     (with-meta (reduce into [] [(prelude lein)
+                                                ["monolith"]
+                                                (prelude "each")
+                                                ["do"
+                                                 "clean,"
+                                                 "install,"
+                                                 "deps"]])
                       ;; something fipp-related (unrelated to our vendored version):
                       {::skip-in-newer-jdks true})}))
 
@@ -256,12 +256,12 @@
   (info "Running `classpath-test!`")
   (letfn [(run [extra-profile]
             {:post [(-> % count pos?)]}
-            (let [{:keys [out err exit]} (apply sh (reduce into [[lein
-                                                                  "with-profile"
-                                                                  (str "-user,-dev" extra-profile)
-                                                                  "classpath"]
-                                                                 [:env env
-                                                                  :dir (System/getProperty "user.dir")]]))]
+            (let [{:keys [out err exit]} (apply sh (reduce into [] [[lein
+                                                                     "with-profile"
+                                                                     (str "-user,-dev" extra-profile)
+                                                                     "classpath"]
+                                                                    [:env env
+                                                                     :dir (System/getProperty "user.dir")]]))]
               (when-not (zero? exit)
                 (println out)
                 (println err)
@@ -321,10 +321,10 @@
       (assert false)))
 
   ;; Pedestal needs separate invocations for `install`, `deps`:
-  (let [{:keys [out exit err]} (apply sh (reduce into [[lein "with-profile" "-user"
-                                                        "sub" "with-profile" "-user" "install"]
-                                                       [:dir (submodule-dir "pedestal")
-                                                        :env env]]))]
+  (let [{:keys [out exit err]} (apply sh (reduce into [] [[lein "with-profile" "-user"
+                                                           "sub" "with-profile" "-user" "install"]
+                                                          [:dir (submodule-dir "pedestal")
+                                                           :env env]]))]
     (when-not (zero? exit)
       (println out)
       (println err)

--- a/integration-testing/integration_test.clj
+++ b/integration-testing/integration_test.clj
@@ -301,7 +301,8 @@
             [_ deps] v
             dep deps]
       (assert (-> dep meta :file not-empty string?)
-              (pr-str {:dep dep
+              (pr-str {:msg "Every dependency must have `:file` metadata, so that the `:shorten` option can work properly."
+                       :dep dep
                        :deps deps
                        :v v}))
       (swap! dep-count inc))

--- a/java/cider/enrich_classpath/Calc72.java
+++ b/java/cider/enrich_classpath/Calc72.java
@@ -4,15 +4,16 @@ import java.io.OutputStream;
 import java.io.IOException;
 
 public class Calc72 {
-    public static OutputStream calc72(OutputStream out, String line) throws IOException {
+    public static OutputStream calc72(OutputStream out, String line, boolean accountForNewlines) throws IOException {
         if (!line.isEmpty()) {
             byte[] lineBytes = line.getBytes("UTF-8");
             int length = lineBytes.length;
             out.write(lineBytes[0]);
             int pos = 1;
-            while (length - pos > 71) {
-                out.write(lineBytes, pos, 71);
-                pos += 71;
+            int threshold = accountForNewlines ? 69 : 71;
+            while (length - pos > threshold) {
+                out.write(lineBytes, pos, threshold);
+                pos += threshold;
                 out.write('\r');
                 out.write('\n');
                 out.write(' ');

--- a/java/cider/enrich_classpath/Calc72.java
+++ b/java/cider/enrich_classpath/Calc72.java
@@ -1,0 +1,23 @@
+package cider.enrich_classpath;
+
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class Calc72 {
+    public static OutputStream calc72(OutputStream out, String line) throws IOException {
+        if (!line.isEmpty()) {
+            byte[] lineBytes = line.getBytes("UTF-8");
+            int length = lineBytes.length;
+            out.write(lineBytes[0]);
+            int pos = 1;
+            while (length - pos > 71) {
+                out.write(lineBytes, pos, 71);
+                pos += 71;
+                out.write('\n');
+                out.write(' ');
+            }
+            out.write(lineBytes, pos, length - pos);
+        }
+        return out;
+    }
+}

--- a/java/cider/enrich_classpath/Calc72.java
+++ b/java/cider/enrich_classpath/Calc72.java
@@ -13,6 +13,7 @@ public class Calc72 {
             while (length - pos > 71) {
                 out.write(lineBytes, pos, 71);
                 pos += 71;
+                out.write('\r');
                 out.write('\n');
                 out.write(' ');
             }

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,5 @@
-(defproject mx.cider/enrich-classpath (if (System/getenv "CIRCLE_TAG")
-                                        (doto (System/getenv "PROJECT_VERSION") assert)
-                                        (or (not-empty (System/getenv "PROJECT_VERSION"))
-                                            "n/a"))
+(defproject mx.cider/enrich-classpath (or (not-empty (System/getenv "PROJECT_VERSION"))
+                                          "0.0.0")
   :description "Makes available .jars with Java sources and javadocs for a given project."
 
   :url "https://github.com/clojure-emacs/enrich-classpath"

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,8 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
+  :java-source-paths ["java"]
+
   :profiles {;; Helps developing the plugin when (false? eval-in-leiningen):
              :test                {:dependencies [[clj-commons/pomegranate "1.2.1"]]}
 

--- a/src/cider/enrich_classpath.clj
+++ b/src/cider/enrich_classpath.clj
@@ -3,6 +3,7 @@
   (:require
    [cemerick.pomegranate.aether]
    [cider.enrich-classpath.collections :refer [add-exclusions-if-classified divide-by ensure-no-lists flatten-deps maybe-normalize safe-sort]]
+   [cider.enrich-classpath.jar :refer [jar-for!]]
    [cider.enrich-classpath.jdk-sources :as jdk-sources]
    [cider.enrich-classpath.locks :refer [read-file! write-file!]]
    [cider.enrich-classpath.logging :refer [debug info warn]]
@@ -23,26 +24,29 @@
       (File. ".enrich-classpath-cache")
       (str)))
 
+(def data-version 1)
+
 (defn serialize
   "Turns any contained coll into a vector, sorting it.
 
-  This ensures that stable values are peristed to the file caches."
+  This ensures that stable values are persisted to the file caches."
   [x]
   {:pre  [(map? x)]
    :post [(vector? %)]}
-  (->> x
-       (mapv (fn outer [[k v]]
-               [(ensure-no-lists k)
-                (some->> v
-                         (mapv (fn inner [[kk vv]]
-                                 [(ensure-no-lists kk) (some->> vv
-                                                                (map ensure-no-lists)
-                                                                safe-sort
-                                                                vec)]))
-                         (safe-sort)
-                         vec)]))
-       safe-sort
-       vec))
+  (with-meta (->> x
+                  (mapv (fn outer [[k v]]
+                          [(ensure-no-lists k)
+                           (some->> v
+                                    (mapv (fn inner [[kk vv]]
+                                            [(ensure-no-lists kk) (some->> vv
+                                                                           (map ensure-no-lists)
+                                                                           safe-sort
+                                                                           vec)]))
+                                    (safe-sort)
+                                    vec)]))
+                  safe-sort
+                  vec)
+    {:enrich-classpath/version data-version}))
 
 (defn deserialize
   "Undoes the work of `#'serialize`.
@@ -51,23 +55,33 @@
   [x]
   {:post [(map? %)]}
   (assert (vector? x) (class x))
-  (->> x
-       (map (fn [[k v]]
-              [k (if (and v (empty? v))
-                   []
-                   (some->> v
-                            (map (fn [[kk vv]]
-                                   [kk (some->> vv
-                                                set)]))
-                            (into {})))]))
-       (into {})))
+  (with-meta (if-not (-> x meta (find :enrich-classpath/version))
+               ;; discard cache values from prior enrich-classpath versions,
+               ;; since they lacked metadata:
+               {}
+               (->> x
+                    (map (fn [[k v]]
+                           [k (if (and v (empty? v))
+                                []
+                                (some->> v
+                                         (map (fn [[kk vv]]
+                                                [kk (some->> vv
+                                                             set)]))
+                                         (into {})))]))
+                    (into {})))
+    {:enrich-classpath/version data-version}))
 
 (defn safe-read-string [x]
   {:pre  [(string? x)]
    :post [(vector? %)]}
   (if (string/blank? x)
     (do
-      (assert (not-any? (comp zero? byte) x)
+      (assert (reduce (fn [_ c]
+                        (if (-> c byte zero?)
+                          (reduced false)
+                          true))
+                      true
+                      x)
               "No ASCII NUL characters should be persisted")
       [])
     (try
@@ -77,7 +91,11 @@
 
 (defn ppr-str [x]
   (with-out-str
-    (fipp.clojure/pprint x)))
+    (fipp.clojure/pprint x
+                         {:print-meta true})))
+
+(def default-cache-contents (ppr-str (with-meta []
+                                       {:enrich-classpath/version data-version})))
 
 (defn make-merge-fn [cache-atom]
   {:pre [@cache-atom]}
@@ -176,6 +194,11 @@
       (swap! cache-atom assoc x v))
     v))
 
+(defn into-distinct [prio non-prio]
+  (into prio
+        (remove (set prio))
+        non-prio))
+
 (defn derivatives [classifiers managed-dependencies memoized-resolve! [dep version & args :as original]]
   (let [version (or version
                     ;; note that managed-dependencies's version only takes precedence
@@ -187,15 +210,14 @@
                          second))]
     (if-not version ;; handles managed-dependencies
       [original]
-      (let [transitive (->> (memoized-resolve! [(assoc-in original [1] version)])
+      (let [transitive (->> (memoized-resolve! [(assoc original 1 version)])
                             flatten-deps)]
         (->> transitive
              (mapcat (fn [[dep version :as original]]
                        (assert version (pr-str original))
                        (->> classifiers
                             (mapv (partial vector dep version :classifier))
-                            (into [original])
-                            (distinct)
+                            (into-distinct [original]) ;; favor the one with meta
                             (remove (comp nil? second))
                             ;; If a *transitive* dependency is explicitly specified by :managed-dependencies,
                             ;; the managed version should take precedence (because that's their whole point):
@@ -215,7 +237,10 @@
                                       (when (some? v)
                                         ;; ...and attach their meta (currently unused),
                                         ;; especially for `:file`:
-                                        (with-meta x (meta v)))))))))
+                                        (with-meta x
+                                          (let [{:keys [file]} (meta v)]
+                                            (when file
+                                              {:file (str file)}))))))))))
              (distinct)
              (vec))))))
 
@@ -283,20 +308,23 @@
                  (-> tools-file .getCanonicalPath))))))
 
 (defn add [{:keys                                                      [repositories
+                                                                        dependencies
                                                                         managed-dependencies
                                                                         java-source-paths
                                                                         resource-paths
                                                                         source-paths
                                                                         test-paths]
-            {:keys               [classifiers]
+            {:keys               [classifiers shorten]
              plugin-repositories :repositories
-             :or                 {classifiers #{"javadoc" "sources"}}} :enrich-classpath
+             :or                 {classifiers #{"javadoc" "sources"}
+                                  shorten false}} :enrich-classpath
             :as                                                        project}]
 
   (debug (str [::classifiers classifiers]))
 
   (write-file! cache-filename (fn [s]
-                                (or (not-empty s) "[]")))
+                                (or (not-empty s)
+                                    default-cache-contents)))
 
   (let [classifiers (set classifiers)
         repositories (or (not-empty plugin-repositories)
@@ -306,7 +334,7 @@
                            repositories)
         initial-cache-value (-> cache-filename read-file! safe-read-string deserialize)
         cache-atom (atom initial-cache-value)
-        add-dependencies (fn [deps]
+        add-dependencies (fn [deps jars?]
                            (let [memoized-resolve! (memoize (partial resolve! cache-atom repositories classifiers))
                                  additions (->> deps
                                                 (divide-by parallelism-factor)
@@ -333,25 +361,32 @@
                                (write-file! cache-filename
                                             (make-merge-fn cache-atom)))
                              ;; order can be sensitive
-                             (into additions deps)))
+                             (if jars?
+                               (->> additions (mapv (comp :file meta)))
+                               (into additions deps))))
         jdk8? (re-find #"^1\.8\." (System/getProperty "java.version"))
         add-tools? (and jdk8?
                         (tools-jar-path))
-        enriched-deps-from-managed-deps (->> managed-dependencies
-                                             add-dependencies
+        enriched-deps-from-managed-deps (->> (add-dependencies managed-dependencies false)
                                              (remove (set managed-dependencies))
                                              (filter (fn [[_ _ classifier]]
                                                        classifier))
                                              (distinct)
                                              (vec))]
     (cond-> project
-      true       (update :dependencies add-dependencies)
-      true       (update :dependencies into enriched-deps-from-managed-deps)
+      (not shorten) (update :dependencies (fn [d]
+                                            (add-dependencies d false)))
+      (not shorten) (update :dependencies into enriched-deps-from-managed-deps)
       add-tools? (update :jar-exclusions conj (-> (tools-jar-path)
                                                   Pattern/quote
                                                   re-pattern))
       add-tools? (update :resource-paths (fn [rp]
                                            (into [(tools-jar-path)] rp)))
+      shorten (update :resource-paths (fn [rp]
+                                        (into (vec (remove nil? [(jar-for! (add-dependencies dependencies true))
+                                                                 (jar-for! (mapv (comp :file meta)
+                                                                                 enriched-deps-from-managed-deps))]))
+                                              rp)))
       (seq java-source-paths) (update :resource-paths (fn [rp]
                                                         (let [corpus (->> java-source-paths
                                                                           (filterv (fn [jsp]

--- a/src/cider/enrich_classpath.clj
+++ b/src/cider/enrich_classpath.clj
@@ -4,6 +4,7 @@
    [cemerick.pomegranate.aether]
    [cider.enrich-classpath.collections :refer [add-exclusions-if-classified divide-by ensure-no-lists flatten-deps maybe-normalize safe-sort]]
    [cider.enrich-classpath.jar :refer [jar-for!]]
+   [cider.enrich-classpath.jdk :as jdk]
    [cider.enrich-classpath.jdk-sources :as jdk-sources]
    [cider.enrich-classpath.locks :refer [read-file! write-file!]]
    [cider.enrich-classpath.logging :refer [debug info warn]]
@@ -361,8 +362,7 @@
                              (if jars?
                                (->> additions (mapv (comp :file meta)))
                                (into additions deps))))
-        jdk8? (re-find #"^1\.8\." (System/getProperty "java.version"))
-        add-tools? (and jdk8?
+        add-tools? (and (jdk/jdk8?)
                         (tools-jar-path))
         enriched-deps-from-managed-deps (->> (add-dependencies managed-dependencies false)
                                              (remove (set managed-dependencies))

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -6,7 +6,7 @@
   (:import
    (cider.enrich_classpath Calc72)
    (java.io ByteArrayOutputStream File PrintStream)
-   (java.util.jar JarOutputStream Manifest)
+   (java.util.jar JarInputStream JarOutputStream Manifest)
    (java.util.zip CRC32)))
 
 ;; Manifest files must be wrapped every 72 lines, with one space of padding for every inserted newline.
@@ -34,6 +34,11 @@ Created-By: mx.cider/enrich-classpath
 
 (defn manifest ^String [classpath]
   (format template classpath))
+
+(defn jar-file->manifest-contents [^File file]
+  (let [os (ByteArrayOutputStream.)]
+    (-> file io/input-stream JarInputStream. .getManifest (.write os))
+    (-> os .toByteArray (String. "UTF-8"))))
 
 (defn jar-for! ^String [jars]
   (when-let [corpus (->> jars

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -9,6 +9,10 @@
    (java.util.jar JarOutputStream Manifest)
    (java.util.zip CRC32)))
 
+;; Manifest files must be wrapped every 72 lines, with one space of padding for every inserted newline.
+;; In principle the `Manifest` class provides this wrapping already, however beyond certain input size,
+;; it will throw an exception.
+;; An already-wrapped string will be accepted by `Manifest` without altering it or throwing any exception.
 (defn wrap72 [s]
   (let [b (ByteArrayOutputStream.)]
     (Calc72/calc72 (PrintStream. b) s)

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -35,7 +35,7 @@ Created-By: mx.cider/enrich-classpath
 (defn manifest ^String [classpath]
   (format template classpath))
 
-(defn jar-for! [jars]
+(defn jar-for! ^String [jars]
   (when-let [corpus (->> jars
                          ;; nil values should never be included (`integration_test.clj` asserts this),
                          ;; but just in case:
@@ -46,7 +46,7 @@ Created-By: mx.cider/enrich-classpath
           dir-crc (-> "user.dir" System/getProperty crc32 str)
           dir (-> "user.home"
                   System/getProperty
-                  (io/file ".mx.cider" "enrich-classpath" (jdk/digits-str) (dir-crc))
+                  (io/file ".mx.cider" "enrich-classpath" (jdk/digits-str) dir-crc)
                   (doto .mkdirs))
           filename (-> dir
                        (io/file (str corpus-crc ".jar"))

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -1,0 +1,45 @@
+(ns cider.enrich-classpath.jar
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string])
+  (:import
+   (cider.enrich_classpath Calc72)
+   (java.io ByteArrayOutputStream File PrintStream)
+   (java.util.jar JarOutputStream Manifest)
+   (java.util.zip CRC32)))
+
+(defn wrap72 [s]
+  (let [b (ByteArrayOutputStream.)]
+    (Calc72/calc72 (PrintStream. b) s)
+    (str b)))
+
+(defn jars->classpath [jars]
+  (wrap72 (str "Class-Path: "
+               (string/join " " jars))))
+
+(def template
+  "Manifest-Version: 1.0
+%s
+Created-By: mx.cider/enrich-classpath
+")
+
+(defn manifest ^String [classpath]
+  (format template classpath))
+
+(defn jar-for! [jars]
+  (when-let [corpus (->> jars
+                         ;; nil values should never be included (`integration_test.clj` asserts this),
+                         ;; but just in case:
+                         (filter some?)
+                         ;; maybe there's nothing to enrich in a small-enough project:
+                         (seq))]
+    (let [sha-bytes (-> corpus string/join .getBytes)
+          sha (-> (CRC32.) (doto (.update sha-bytes 0 (alength sha-bytes))) .getValue)
+          filename (str sha ".jar")]
+
+      (when-not (-> filename File. .exists)
+        (let [manifest-contents (-> corpus jars->classpath manifest)
+              manifest (-> manifest-contents (.getBytes "UTF-8") io/input-stream Manifest.)]
+          (-> filename io/output-stream (JarOutputStream. manifest) (.close))))
+
+      filename)))

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -15,7 +15,9 @@
 ;; An already-wrapped string will be accepted by `Manifest` without altering it or throwing any exception.
 (defn wrap72 [s]
   (let [b (ByteArrayOutputStream.)]
-    (Calc72/calc72 (PrintStream. b) s)
+    (Calc72/calc72 (PrintStream. b)
+                   s
+                   (boolean (re-find #"^1\.8\." (System/getProperty "java.version"))))
     (str b)))
 
 (defn crc32 [^String s]

--- a/src/cider/enrich_classpath/jar.clj
+++ b/src/cider/enrich_classpath/jar.clj
@@ -17,7 +17,7 @@
   (let [b (ByteArrayOutputStream.)]
     (Calc72/calc72 (PrintStream. b)
                    s
-                   (boolean (re-find #"^1\.8\." (System/getProperty "java.version"))))
+                   (boolean (jdk/jdk8?)))
     (str b)))
 
 (defn crc32 [^String s]

--- a/src/cider/enrich_classpath/jdk.clj
+++ b/src/cider/enrich_classpath/jdk.clj
@@ -4,3 +4,6 @@
 
 (defn digits-str []
   (->> "java.version" System/getProperty (re-seq #"\d+") (string/join)))
+
+(defn jdk8? []
+  (boolean (re-find #"^1\.8\." (System/getProperty "java.version"))))

--- a/src/cider/enrich_classpath/jdk.clj
+++ b/src/cider/enrich_classpath/jdk.clj
@@ -1,0 +1,6 @@
+(ns cider.enrich-classpath.jdk
+  (:require
+   [clojure.string :as string]))
+
+(defn digits-str []
+  (->> "java.version" System/getProperty (re-seq #"\d+") (string/join)))

--- a/src/cider/enrich_classpath/jdk_sources.clj
+++ b/src/cider/enrich_classpath/jdk_sources.clj
@@ -1,5 +1,6 @@
 (ns cider.enrich-classpath.jdk-sources
   (:require
+   [cider.enrich-classpath.jdk :as jdk]
    [cider.enrich-classpath.locks :refer [locking-file]]
    [cider.enrich-classpath.logging :refer [warn]]
    [clojure.java.io :as io]
@@ -68,7 +69,7 @@
             (-> output .close)))))))
 
 (defn uncompressed-sources-dir []
-  (let [id (->> "java.version" System/getProperty (re-seq #"\d+") (string/join))]
+  (let [id (jdk/digits-str)]
     (-> "user.home"
         System/getProperty
         (io/file ".mx.cider" "unzipped-jdk-sources" id)

--- a/src/cider/enrich_classpath/jdk_sources.clj
+++ b/src/cider/enrich_classpath/jdk_sources.clj
@@ -93,9 +93,7 @@
                         (uncompress dir choice)))))
     dir))
 
-(def jdk8? (->> "java.version" System/getProperty (re-find #"^1.8.")))
-
 (defn resources-to-add []
   (cond-> []
-    (and jdk-sources jdk8?) (conj (unzipped-jdk-source))
+    (and jdk-sources jdk/jdk8?) (conj (unzipped-jdk-source))
     jdk-sources             (conj jdk-sources)))

--- a/src/cider/enrich_classpath/version.clj
+++ b/src/cider/enrich_classpath/version.clj
@@ -1,0 +1,8 @@
+(ns cider.enrich-classpath.version)
+
+(def data-version 1)
+
+(defn outdated-data-version? [m]
+  (-> m
+      :enrich-classpath/version ;; can be nil (handling maps before versioning was introduced)
+      (not= data-version)))

--- a/src/cider/enrich_classpath/version.clj
+++ b/src/cider/enrich_classpath/version.clj
@@ -2,7 +2,11 @@
 
 (def data-version 1)
 
+(defn long-not= [^long x, ^long y] ;; coerces to primitive long at the edges
+  (not= x y))
+
 (defn outdated-data-version? [m]
   (-> m
       :enrich-classpath/version ;; can be nil (handling maps before versioning was introduced)
-      (not= data-version)))
+      (or 0)
+      (long-not= data-version)))

--- a/test/integration/cider/enrich_classpath.clj
+++ b/test/integration/cider/enrich_classpath.clj
@@ -30,8 +30,8 @@
                                   (is (= expected v))
                                   (is (= expected (locks/read-file! filename))))
                                 true)
-          (swap! state assoc [[4]] {[5 6] nil}) "[[[[4]] [[[5 6] nil]]]]\n"
-          (swap! state assoc [[1]] {[2 3] nil}) "[[[[1]] [[[2 3] nil]]] [[[4]] [[[5 6] nil]]]]\n")
+          (swap! state assoc [[4]] {[5 6] nil}) "^{:enrich-classpath/version 1}\n[[[[4]] [[[5 6] nil]]]]\n"
+          (swap! state assoc [[1]] {[2 3] nil}) "^{:enrich-classpath/version 1}\n[[[[1]] [[[2 3] nil]]] [[[4]] [[[5 6] nil]]]]\n")
         (finally
           (-> file .delete))))))
 

--- a/test/integration/cider/enrich_classpath/jar.clj
+++ b/test/integration/cider/enrich_classpath/jar.clj
@@ -10,8 +10,7 @@
 (deftest jar-for!
   (let [jars [(-> (UUID/randomUUID) str),
               (-> (UUID/randomUUID) str)]
-        filename (sut/jar-for! jars)
-        ^File file (File. filename)
+        file (File. (sut/jar-for! jars))
         last-modified (-> file .lastModified)]
     (is (-> file .exists)
         "Creates a file")
@@ -27,5 +26,5 @@ Class-Path: [a-z0-9-]+ [a-z0-9-]+
  [a-z0-9-]+
 Created-By: mx.cider/enrich-classpath"
                      (string/replace v "\r" ""))
-            "Emits a valid Manifest file with two classpath entries of in it,
+            "Emits a valid Manifest file with two classpath entries in it,
 the former being wrapped at column 72, and the latter prefixed by a single space character")))))

--- a/test/integration/cider/enrich_classpath/jar.clj
+++ b/test/integration/cider/enrich_classpath/jar.clj
@@ -1,0 +1,35 @@
+(ns integration.cider.enrich-classpath.jar
+  (:require
+   [cider.enrich-classpath.jar :as sut]
+   [clojure.java.io :as io]
+   [clojure.string :as string]
+   [clojure.test :refer [deftest is testing]])
+  (:import
+   (java.io ByteArrayOutputStream File)
+   (java.util UUID)
+   (java.util.jar JarInputStream)))
+
+(deftest jar-for!
+  (let [jars [(-> (UUID/randomUUID) str),
+              (-> (UUID/randomUUID) str)]
+        filename (sut/jar-for! jars)
+        ^File file (File. filename)
+        last-modified (-> file .lastModified)]
+    (is (-> file .exists)
+        "Creates a file")
+    (is (= last-modified
+           (-> (sut/jar-for! jars)
+               File.
+               .lastModified))
+        "Doesn't re-create the same .jar for equivalent contents")
+    (let [os (ByteArrayOutputStream.)
+          _ (-> file io/input-stream JarInputStream. .getManifest (.write os))
+          v (-> os .toByteArray (String. "UTF-8"))]
+      (testing v
+        (is (re-find #"Manifest-Version: 1.0
+Class-Path: [a-z0-9-]+ [a-z0-9-]+
+ [a-z0-9-]+
+Created-By: mx.cider/enrich-classpath"
+                     (string/replace v "\r" ""))
+            "Emits a valid Manifest file with two classpath entries of in it,
+the former being wrapped at column 72, and the latter prefixed by a single space character")))))

--- a/test/integration/cider/enrich_classpath/jar.clj
+++ b/test/integration/cider/enrich_classpath/jar.clj
@@ -1,13 +1,11 @@
 (ns integration.cider.enrich-classpath.jar
   (:require
    [cider.enrich-classpath.jar :as sut]
-   [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]])
   (:import
-   (java.io ByteArrayOutputStream File)
-   (java.util UUID)
-   (java.util.jar JarInputStream)))
+   (java.io File)
+   (java.util UUID)))
 
 (deftest jar-for!
   (let [jars [(-> (UUID/randomUUID) str),
@@ -22,9 +20,7 @@
                File.
                .lastModified))
         "Doesn't re-create the same .jar for equivalent contents")
-    (let [os (ByteArrayOutputStream.)
-          _ (-> file io/input-stream JarInputStream. .getManifest (.write os))
-          v (-> os .toByteArray (String. "UTF-8"))]
+    (let [v (sut/jar-file->manifest-contents file)]
       (testing v
         (is (re-find #"Manifest-Version: 1.0
 Class-Path: [a-z0-9-]+ [a-z0-9-]+

--- a/test/unit/cider/enrich_classpath/jar.clj
+++ b/test/unit/cider/enrich_classpath/jar.clj
@@ -9,15 +9,22 @@
     (are [input expected-output expected-newline-count] (testing input
                                                           (is (= expected-output
                                                                  (sut/wrap72 input)))
+                                                          (is (<= (->> input
+                                                                       sut/wrap72
+                                                                       string/split-lines
+                                                                       (map count)
+                                                                       (apply max)
+                                                                       (long))
+                                                                  72))
                                                           (is (= expected-newline-count
                                                                  (->> input
                                                                       sut/wrap72
-                                                                      (re-seq #"\n ")
+                                                                      (re-seq #"\r\n ")
                                                                       (count))))
                                                           (is (= input
                                                                  (-> input
                                                                      sut/wrap72
-                                                                     (string/split #"\n ")
+                                                                     (string/split #"\r\n ")
                                                                      (string/join)))
                                                               "The output has essentially the same info than the input, with no info being lost or added")
                                                           true)
@@ -26,9 +33,9 @@
       0
 
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar"
-      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\n -clj-1.0.594-alpha.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\r\n -clj-1.0.594-alpha.jar"
       1
 
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0.jar"
-      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\n -clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/\n checker-qual/2.0.0/checker-qual-2.0.0.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\r\n -clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/\r\n checker-qual/2.0.0/checker-qual-2.0.0.jar"
       2)))

--- a/test/unit/cider/enrich_classpath/jar.clj
+++ b/test/unit/cider/enrich_classpath/jar.clj
@@ -6,36 +6,43 @@
 
 (deftest wrap72
   (testing "Wraps text every 72 characters, inserting one space of padding for every inserted line break"
-    (are [input expected-output expected-newline-count] (testing input
-                                                          (is (= expected-output
-                                                                 (sut/wrap72 input)))
-                                                          (is (<= (->> input
-                                                                       sut/wrap72
-                                                                       string/split-lines
-                                                                       (map count)
-                                                                       (apply max)
-                                                                       (long))
-                                                                  72))
-                                                          (is (= expected-newline-count
-                                                                 (->> input
-                                                                      sut/wrap72
-                                                                      (re-seq #"\r\n ")
-                                                                      (count))))
-                                                          (is (= input
-                                                                 (-> input
-                                                                     sut/wrap72
-                                                                     (string/split #"\r\n ")
-                                                                     (string/join)))
-                                                              "The output has essentially the same info than the input, with no info being lost or added")
-                                                          true)
+    (are [input expected-output expected-output-jdk8 expected-newline-count]
+        (testing input
+          (if (re-find #"^1\.8\." (System/getProperty "java.version"))
+            (is (= expected-output-jdk8
+                   (sut/wrap72 input)))
+            (is (= expected-output
+                   (sut/wrap72 input))))
+          (is (<= (->> input
+                       sut/wrap72
+                       string/split-lines
+                       (map count)
+                       (apply max)
+                       (long))
+                  72))
+          (is (= expected-newline-count
+                 (->> input
+                      sut/wrap72
+                      (re-seq #"\r\n ")
+                      (count))))
+          (is (= input
+                 (-> input
+                     sut/wrap72
+                     (string/split #"\r\n ")
+                     (string/join)))
+              "The output has essentially the same info than the input, with no info being lost or added")
+          true)
+      "a"
       "a"
       "a"
       0
 
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar"
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\r\n -clj-1.0.594-alpha.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewri\r\n te-clj-1.0.594-alpha.jar"
       1
 
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0.jar"
       "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\r\n -clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/\r\n checker-qual/2.0.0/checker-qual-2.0.0.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewri\r\n te-clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframew\r\n ork/checker-qual/2.0.0/checker-qual-2.0.0.jar"
       2)))

--- a/test/unit/cider/enrich_classpath/jar.clj
+++ b/test/unit/cider/enrich_classpath/jar.clj
@@ -1,0 +1,34 @@
+(ns unit.cider.enrich-classpath.jar
+  (:require
+   [cider.enrich-classpath.jar :as sut]
+   [clojure.string :as string]
+   [clojure.test :refer [are deftest is testing]]))
+
+(deftest wrap72
+  (testing "Wraps text every 72 characters, inserting one space of padding for every inserted line break"
+    (are [input expected-output expected-newline-count] (testing input
+                                                          (is (= expected-output
+                                                                 (sut/wrap72 input)))
+                                                          (is (= expected-newline-count
+                                                                 (->> input
+                                                                      sut/wrap72
+                                                                      (re-seq #"\n ")
+                                                                      (count))))
+                                                          (is (= input
+                                                                 (-> input
+                                                                     sut/wrap72
+                                                                     (string/split #"\n ")
+                                                                     (string/join)))
+                                                              "The output has essentially the same info than the input, with no info being lost or added")
+                                                          true)
+      "a"
+      "a"
+      0
+
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\n -clj-1.0.594-alpha.jar"
+      1
+
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite-clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/checker-qual/2.0.0/checker-qual-2.0.0.jar"
+      "/Users/vemv/.m2/repository/rewrite-clj/rewrite-clj/1.0.594-alpha/rewrite\n -clj-1.0.594-alpha.jar /Users/vemv/.m2/repository/org/checkerframework/\n checker-qual/2.0.0/checker-qual-2.0.0.jar"
+      2)))

--- a/test/unit/cider/enrich_classpath/version.clj
+++ b/test/unit/cider/enrich_classpath/version.clj
@@ -1,0 +1,14 @@
+(ns unit.cider.enrich-classpath.version
+  (:require
+   [cider.enrich-classpath.version :as sut]
+   [clojure.test :refer [are deftest is testing]]))
+
+(deftest outdated-data-version?
+  (are [input expected] (testing input
+                          (is (= expected
+                                 (sut/outdated-data-version? input)))
+                          true)
+    nil                                                true
+    {}                                                 true
+    {:enrich-classpath/version (dec sut/data-version)} true
+    {:enrich-classpath/version sut/data-version}       false))

--- a/test/unit/cider/enrich_classpath/version.clj
+++ b/test/unit/cider/enrich_classpath/version.clj
@@ -8,7 +8,7 @@
                           (is (= expected
                                  (sut/outdated-data-version? input)))
                           true)
-    nil                                                true
-    {}                                                 true
-    {:enrich-classpath/version (dec sut/data-version)} true
-    {:enrich-classpath/version sut/data-version}       false))
+    nil                                                        true
+    {}                                                         true
+    {:enrich-classpath/version (-> sut/data-version long dec)} true
+    {:enrich-classpath/version sut/data-version}               false))


### PR DESCRIPTION
This option allows to fix `Argument list too long` errors as reflected in https://github.com/clojure-emacs/cider/issues/3136, by favoring enriching the classpath with shallow .jars that refer to other .jars via `META-INF/MANIFEST.MF` files.

This option will become the default at some point, but needs some QAing first.