### PR TITLE
Add `com.sun.tools.javac.code` opens

### DIFF
--- a/lein-plugin/src/cider/enrich_classpath/plugin_v2.clj
+++ b/lein-plugin/src/cider/enrich_classpath/plugin_v2.clj
@@ -86,7 +86,12 @@
                                (update :middleware remove-enrich-middleware))]))
         m))
 
-(defn middleware* [{:keys [repl-options java-source-paths] :as project}]
+(def default-main "nrepl.cmdline")
+
+(defn middleware* [{:keys [repl-options java-source-paths]
+                    {:keys [main]
+                     :or {main default-main}} :enrich-classpath
+                    :as project}]
 
   (when (seq java-source-paths)
     (binding [leiningen.core.main/*exit-process?* false]
@@ -136,12 +141,15 @@
 
         enriched-classpath (str orig sep suffix)
         init-form (build-init-form project)]
-    (format "%s -cp %s%sclojure.main%s-m nrepl.cmdline %s"
+    (format "%s -cp %s%sclojure.main%s-m %s %s"
             java
             enriched-classpath
             (format-jvm-opts project)
             init-form
-            nrepl-options)))
+            main
+            (if (= main default-main)
+              nrepl-options
+              ""))))
 
 (defn middleware [project]
   ;; XXX failsafe. as a last resource, `echo` the strace

--- a/lein-plugin/src/cider/enrich_classpath/plugin_v2.clj
+++ b/lein-plugin/src/cider/enrich_classpath/plugin_v2.clj
@@ -65,7 +65,7 @@
 
 (defn build-init-form [{{:keys [init init-ns]} :repl-options
                         :keys [global-vars]}]
-  (or (when (or init init-ns global-vars)
+  (or (when (or init init-ns (seq global-vars))
         (str " --eval "
              (pr-str (pr-str (wrap-try init-ns init global-vars)))
              " "))

--- a/lein-plugin/test/integration/cider/enrich_classpath/plugin_v2.clj
+++ b/lein-plugin/test/integration/cider/enrich_classpath/plugin_v2.clj
@@ -36,15 +36,16 @@
         [java cp classpath jvmopt1 jvmopt2 compile-path]
         segments
 
-        [add-opens clojure-main eval-flag eval-code m nrepl host localhost port portno]
-        (take-last 10 segments)
+        [add-opens add-opens2 clojure-main eval-flag eval-code m nrepl host localhost port portno]
+        (take-last 11 segments)
 
         classpath (-> classpath
                       (string/replace (System/getProperty "user.home") "~")
                       (string/replace "~/repo/" "~/enrich-classpath/")
                       (string/replace #"mx.cider/enrich-classpath/\d+/\d+/\d+.jar"
                                       "mx.cider/enrich-classpath/<shortened>.jar"))
-        expected-add-opens "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"]
+        expected-add-opens  "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+        expected-add-opens2 "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"]
     (testing all
       (is (= "java" java))
       (is (= "-cp" cp))
@@ -56,6 +57,10 @@
         (is (not= expected-add-opens add-opens)
             "Does not add the opens for this JDK")
         (is (= expected-add-opens add-opens)))
+      (if (jdk8?)
+        (is (not= expected-add-opens2 add-opens2)
+            "Does not add the opens for this JDK")
+        (is (= expected-add-opens2 add-opens2)))
       (is (= "clojure.main" clojure-main))
       (is (= "--eval" eval-flag))
       (is (= "\"(clojure.core/+)\"" eval-code))

--- a/lein-plugin/test/unit/cider/enrich_classpath/plugin_v2.clj
+++ b/lein-plugin/test/unit/cider/enrich_classpath/plugin_v2.clj
@@ -12,6 +12,9 @@
     {}
     " "
 
+    {:global-vars []}
+    " "
+
     {:repl-options {:init 2}}
     " --eval \"(try 2 (catch java.lang.Throwable e (.printStackTrace e)))\" "
 

--- a/src/cider/enrich_classpath/jdk.clj
+++ b/src/cider/enrich_classpath/jdk.clj
@@ -9,14 +9,22 @@
   (boolean (re-find #"^1\.8\." (System/getProperty "java.version"))))
 
 (def javac-tree "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED")
+(def javac-code "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED")
 
 (def javac-tree-opens (str "--add-opens=" javac-tree))
+(def javac-code-opens (str "--add-opens=" javac-code))
 
 (def javac-tree-like #{javac-tree javac-tree-opens})
+(def javac-code-like #{javac-code javac-code-opens})
 
 (defn maybe-add-opens [xs]
   (cond-> xs
     (and (not (jdk8?))
          (not (some javac-tree-like xs)))
 
-    (conj javac-tree-opens)))
+    (conj javac-tree-opens)
+
+    (and (not (jdk8?))
+         (not (some javac-code-like xs)))
+
+    (conj javac-code-opens)))

--- a/tools.deps/src/cider/enrich_classpath/clojure.clj
+++ b/tools.deps/src/cider/enrich_classpath/clojure.clj
@@ -165,6 +165,10 @@
                       (jdk/jdk8?))
                 []
                 [(str "-J" jdk/javac-tree-opens)]))
+        (into (if (or (some jdk/javac-code-like calculated-jvm-opts)
+                      (jdk/jdk8?))
+                []
+                [(str "-J" jdk/javac-code-opens)]))
         (into (if (seq main-opts)
                 main-opts
                 []))

--- a/tools.deps/test/integration/cider/enrich_classpath/clojure.clj
+++ b/tools.deps/test/integration/cider/enrich_classpath/clojure.clj
@@ -90,7 +90,8 @@
                      (pr-str '{:deps {nrepl/nrepl {:mvn/version "1.0.0"} cider/cider-nrepl {:mvn/version "0.36.0"} refactor-nrepl/refactor-nrepl {:mvn/version "3.9.0"}} :aliases {:cider/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"]}}})
                      "-M:dev:test:cider/nrepl"]
                     false)
-        opens "-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"]
+        opens "-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+        opens2 "-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"]
     (testing v
       (is (string/starts-with? v
                                "clojure -Sforce -Srepro -J-XX:-OmitStackTraceInFastThrow -J-Dclojure.main.report=stderr -Scp")
@@ -103,7 +104,10 @@
           "Adds the cider-nrepl dep and program based on the -Sdeps and -M args")
       (if (jdk/jdk8?)
         (is (not (string/includes? v opens)))
-        (is (string/includes? v opens))))))
+        (is (string/includes? v opens)))
+      (if (jdk/jdk8?)
+        (is (not (string/includes? v opens2)))
+        (is (string/includes? v opens2))))))
 
 (deftest classpath-overrides
   (let [cp (sut/impl "clojure"


### PR DESCRIPTION
* Don't emit empty `--eval`s
* Leiningen plugin: support a custom `:main` program
  * This enables using enrich-classpath while e.g. running tests (rather than using a repl, which is its main use case).
* Add `com.sun.tools.javac.code` opens
  * Supports an Orchard feature.