### PR TITLE
Add :exclusions to non maven libraries descriptions

### DIFF
--- a/tools.deps/src/cider/enrich_classpath/clojure.clj
+++ b/tools.deps/src/cider/enrich_classpath/clojure.clj
@@ -162,7 +162,9 @@
                                                                               (when (seq (select-keys m [:git/url :git/sha :git/tag :sha :tag
                                                                                                          :local/root]))
                                                                                 ;; use m (and not the select-keys result) to honor `:exclusions`:
-                                                                                [dep m])))
+                                                                                [dep (-> m
+                                                                                         (update :exclusions into classpath-overrides-vector)
+                                                                                         (update :exclusions vec))])))
                                                                       (into {})))})
         ;; Avoids
         ;; `WARNING: Use of :paths external to the project has been deprecated, please remove: ...`:

--- a/tools.deps/test-resources/flowstorm2/deps.edn
+++ b/tools.deps/test-resources/flowstorm2/deps.edn
@@ -1,0 +1,6 @@
+;; Adding a dependency that contains clojure 1.11.1 as a transitive
+{:deps {io.github.nubank/morse {:git/tag "v2023.10.06.02" :git/sha "88b5ff7"}}
+ :aliases
+ ;; let's swap the Clojure compiler by ClojureStorm
+ {:storm {:classpath-overrides {org.clojure/clojure nil} ;; for disabling the official compiler
+          :deps                {com.github.flow-storm/clojure {:mvn/version "1.12.0-alpha9_4"}}}}}

--- a/tools.deps/test/integration/cider/enrich_classpath/clojure.clj
+++ b/tools.deps/test/integration/cider/enrich_classpath/clojure.clj
@@ -128,6 +128,17 @@
     (is (not (string/includes? cp "org/clojure/clojure"))
         "Honors `:classpath-overrides`")))
 
+(deftest classpath-overrides-git-deps
+  (let [cp (sut/impl "clojure"
+                     "deps.edn"
+                     (str (io/file (System/getProperty "user.dir") "test-resources" "flowstorm2"))
+                     ["-A:storm"]
+                     false)]
+    (is (string/includes? cp "com/github/flow-storm/clojure/1.12.0-alpha9_4/clojure-1.12.0-alpha9_4.jar")
+        "Honors `:classpath-overrides`")
+    (is (not (string/includes? cp "org/clojure/clojure"))
+        "Honors `:classpath-overrides`")))
+
 (deftest bouncy-repro
   (testing "A problematic real-world case doesn't throw exceptions"
     (let [actual (sut/impl "clojure"


### PR DESCRIPTION
Currently when a :classpath-override map is provided in deps.edn the overrides vector is being added as exclusions only to maven libraries.

So if we have a library, like in this case `io.github.nubank/morse` which includes a version of `org.clojure/clojure`, and
we are adding it as a git lib, like this : 
```clojure
{:aliases
 {:dev
  {:extra-deps
   :classpath-overrides {org.clojure/clojure nil} ;; swapping compilers
   {com.github.flow-storm/clojure {:mvn/version "1.11.2-4"}
    io.github.nubank/morse {:git/tag "v2023.10.06.02" :git/sha "88b5ff7"}}}}}
```
then the resulting classpath will include `org.clojure/clojure` even if we told it to exclude it.

This PR fixes this. Not sure how this affects the lein path of this tool.